### PR TITLE
Print items as they are received in --follow mode

### DIFF
--- a/pkg/output/flag.go
+++ b/pkg/output/flag.go
@@ -30,6 +30,7 @@ const (
 	FlagOutput = "output"
 	FlagFields = "fields"
 	FlagLimit  = "limit"
+	FlagFollow = "follow"
 
 	FieldsLong = "long"
 )

--- a/pkg/output/printer.go
+++ b/pkg/output/printer.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	BatchPrintSize = 100 // for consistent formatting, print items in batches (ex. in Table output)
+	BatchPrintSize = 100
 )
 
 type PrintOptions struct {
@@ -121,10 +121,13 @@ func Pager(c *cli.Context, iter iterator.Iterator, opts *PrintOptions) error {
 		batch = append(batch, item)
 		itemsPrinted++
 
+		follow := c.Bool(FlagFollow)
 		isLastBatch := limit-itemsPrinted < BatchPrintSize
 		isBatchFilled := (len(batch) == BatchPrintSize) || (isLastBatch && len(batch) == limit%BatchPrintSize)
 
-		if isBatchFilled || !iter.HasNext() {
+		if follow || isBatchFilled || !iter.HasNext() {
+			// for consistent formatting, print items in batches (ex. in Table output)
+			// else if --follow is on, print items as they are received
 			PrintItems(c, batch, opts)
 			batch = batch[:0]
 			opts.NoHeader = true


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

tctl commands with `--follow` mode on would get stuck at printing until there are more than 100 items (page size) in the queue to print. The PR makes `--follow` print immediately w/o waiting for 100 items in the queue 

## Why?
<!-- Tell your future self why have you made these changes -->

fixes UX for `--follow` command

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

tested on `workflow show --follow` on an event history < 100 items and new event items coming every few seconds

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
