### PR TITLE
Switch to setting config values by full key

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -64,40 +64,20 @@ func NewConfig(appName, configName string) (*Config, error) {
 	return &Config{viper: v}, nil
 }
 
+func (c *Config) Get(ctx *cli.Context, key string) (string, error) {
+	if c.viper.IsSet(key) {
+		return c.viper.GetString(key), nil
+	}
+
+	return "", nil
+}
+
 func (c *Config) GetByEnvironment(ctx *cli.Context, key string) (string, error) {
 	activeEnv := c.viper.GetString(KeyActive)
 	fullKey := getFullKey(activeEnv, key)
 
 	if c.viper.IsSet(fullKey) {
 		return c.viper.GetString(fullKey), nil
-	}
-
-	return "", nil
-}
-
-func (c *Config) SetByEnvironment(ctx *cli.Context, key string, value string) error {
-	activeEnv := c.viper.GetString(KeyActive)
-	if activeEnv == "" {
-		return fmt.Errorf("active environment not set")
-	}
-
-	fullKey := getFullKey(activeEnv, key)
-	c.viper.Set(fullKey, value)
-
-	if err := c.viper.WriteConfig(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func getFullKey(env, path string) string {
-	return KeyEnvironment + "." + env + "." + path
-}
-
-func (c *Config) Get(ctx *cli.Context, key string) (string, error) {
-	if c.viper.IsSet(key) {
-		return c.viper.GetString(key), nil
 	}
 
 	return "", nil
@@ -140,4 +120,8 @@ func mkdir(path string) error {
 	}
 
 	return nil
+}
+
+func getFullKey(env, path string) string {
+	return KeyEnvironment + "." + env + "." + path
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

removed SetByEnvironment. Now requires to always specify the full key path

## Why?
<!-- Tell your future self why have you made these changes -->

changing tctl config semantics from flags -> full arguments
```
tctl config set --namespace default
```

to 

```
tctl config set environments.local.namespace default
```

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
