### PR TITLE
Change config semantics environments -> env

### DIFF
--- a/pkg/config/alias.go
+++ b/pkg/config/alias.go
@@ -36,8 +36,8 @@ func (c *Config) GetAlias(alias string) (string, error) {
 }
 
 func (c *Config) GetAliases() (map[string]string, error) {
-	if c.viper.IsSet(KeyAlias) {
-		return c.viper.GetStringMapString(KeyAlias), nil
+	if c.viper.IsSet(KeyAliases) {
+		return c.viper.GetStringMapString(KeyAliases), nil
 	}
 
 	return map[string]string{}, nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -49,8 +49,8 @@ func NewConfig(appName, configName string) (*Config, error) {
 	v.AddConfigPath(dpath)
 	v.SetConfigName(configName)
 	v.SetConfigType("yaml")
-	v.SetDefault(KeyAlias, map[string]string{})
-	v.SetDefault(KeyActive, "local")
+	v.SetDefault(KeyAliases, map[string]string{})
+	v.SetDefault(KeyCurrentEnvironment, "local")
 	v.SetDefault(KeyEnvironment, map[string]interface{}{"local": nil})
 
 	if err := v.ReadInConfig(); err != nil {
@@ -72,9 +72,9 @@ func (c *Config) Get(ctx *cli.Context, key string) (string, error) {
 	return "", nil
 }
 
-func (c *Config) GetByEnvironment(ctx *cli.Context, key string) (string, error) {
-	activeEnv := c.viper.GetString(KeyActive)
-	fullKey := getFullKey(activeEnv, key)
+func (c *Config) GetByCurrentEnvironment(ctx *cli.Context, key string) (string, error) {
+	env := c.viper.GetString(KeyCurrentEnvironment)
+	fullKey := getFullKey(env, key)
 
 	if c.viper.IsSet(fullKey) {
 		return c.viper.GetString(fullKey), nil

--- a/pkg/config/defs.go
+++ b/pkg/config/defs.go
@@ -23,7 +23,7 @@
 package config
 
 const (
-	KeyActive      string = "active"
-	KeyAlias       string = "aliases"
-	KeyEnvironment string = "environments"
+	KeyAliases            string = "aliases"
+	KeyCurrentEnvironment string = "current-env"
+	KeyEnvironment        string = "env"
 )


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

changed config keys
`environments` -> `envs`
`active` -> `current-env`

## Why?
<!-- Tell your future self why have you made these changes -->

shorter usage `tctl config set env.local.namespace` vs  `tctl config set environments.local.namespace`

`tctl config use-env` vs `tctl config use-environment`

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
