### PR TITLE
Fix config overriding entire env object

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -51,7 +51,7 @@ func NewConfig(appName, configName string) (*Config, error) {
 	v.SetConfigType("yaml")
 	v.SetDefault(KeyAliases, map[string]string{})
 	v.SetDefault(KeyCurrentEnvironment, "local")
-	v.SetDefault(KeyEnvironment, map[string]interface{}{"local": nil})
+	v.SetDefault(KeyEnvironment, map[string]map[string]string{"local": nil})
 
 	if err := v.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Change `env` key from interface{} to a map

## Why?
<!-- Tell your future self why have you made these changes -->

starts adding keys to an `env` instead of overriding entire thing

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
