### PR TITLE
Add API to read a config env entrance

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -77,6 +77,15 @@ func (c *Config) Get(key string) (string, error) {
 	return "", nil
 }
 
+func (c *Config) GetEnv(name string) (map[string]string, error) {
+	err := validateKey(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.viper.GetStringMapString(KeyEnvironment + "." + name), nil
+}
+
 func (c *Config) GetByCurrentEnvironment(key string) (string, error) {
 	env := c.viper.GetString(KeyCurrentEnvironment)
 	fullKey := getFullKey(env, key)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Adds a function to read entire env props, returned as `map[string]string`

## Why?
<!-- Tell your future self why have you made these changes -->

helpful when printing env properties

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

unit tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
