### PR TITLE
Replace less with stdout as the default output

### DIFF
--- a/pkg/output/card.go
+++ b/pkg/output/card.go
@@ -26,14 +26,14 @@ package output
 
 import (
 	"fmt"
-
-	"github.com/urfave/cli/v2"
+	"io"
 
 	"github.com/temporalio/tctl-kit/pkg/color"
 	"github.com/temporalio/tctl-kit/pkg/process"
+	"github.com/urfave/cli/v2"
 )
 
-func PrintCards(c *cli.Context, items []interface{}, opts *PrintOptions) {
+func PrintCards(c *cli.Context, w io.Writer, items []interface{}, opts *PrintOptions) {
 	rows, err := extractFieldValues(items, opts.Fields)
 	if err != nil {
 		process.ErrorAndExit("unable to print card", err)
@@ -45,7 +45,6 @@ func PrintCards(c *cli.Context, items []interface{}, opts *PrintOptions) {
 		fieldNames[i] = nestedFields[len(nestedFields)-1]
 	}
 
-	w := opts.Pager
 	for _, row := range rows {
 		fmt.Fprintf(w, "---------------------------------------------------\n")
 		for j, col := range row {

--- a/pkg/output/json.go
+++ b/pkg/output/json.go
@@ -28,24 +28,24 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
 	"github.com/hokaccha/go-prettyjson"
-	"github.com/urfave/cli/v2"
-
 	"github.com/temporalio/tctl-kit/pkg/color"
+	"github.com/urfave/cli/v2"
 )
 
-func PrintJSON(c *cli.Context, o interface{}, opts *PrintOptions) {
+func PrintJSON(c *cli.Context, w io.Writer, o interface{}) {
 	json, err := ParseToJSON(c, o, true)
 
 	if err != nil {
 		fmt.Printf("Error when try to print pretty: %v\n", err)
-		fmt.Fprintln(opts.Pager, o)
+		fmt.Fprintln(w, o)
 	}
 
-	fmt.Fprintln(opts.Pager, json)
+	fmt.Fprintln(w, json)
 }
 
 func ParseToJSON(c *cli.Context, o interface{}, indent bool) (string, error) {

--- a/pkg/output/printer.go
+++ b/pkg/output/printer.go
@@ -47,8 +47,8 @@ type PrintOptions struct {
 	FieldsLong []string
 	// ForceFields ignores user provided fields and uses print options instead. Useful when printing secondary data
 	ForceFields bool
-	// Output is the output format to use: table, json..
-	Output OutputOption
+	// OutputFormat is the output format to use: table, json..
+	OutputFormat OutputOption
 	// Pager is the pager to use for interactive mode. Default - stdout
 	Pager pager.PagerOption
 	// NoHeader removes the header in the table output
@@ -141,8 +141,8 @@ func getOutputFormat(c *cli.Context, opts *PrintOptions) OutputOption {
 	if opts != nil {
 		if c.IsSet(FlagOutput) {
 			return output
-		} else if opts.Output != "" {
-			return opts.Output
+		} else if opts.OutputFormat != "" {
+			return opts.OutputFormat
 		}
 	}
 

--- a/pkg/output/table.go
+++ b/pkg/output/table.go
@@ -25,22 +25,23 @@
 package output
 
 import (
-	"github.com/olekukonko/tablewriter"
-	"github.com/urfave/cli/v2"
+	"io"
 
+	"github.com/olekukonko/tablewriter"
 	"github.com/temporalio/tctl-kit/pkg/color"
 	"github.com/temporalio/tctl-kit/pkg/process"
+	"github.com/urfave/cli/v2"
 )
 
 var (
 	headerColor = tablewriter.Colors{tablewriter.FgHiMagentaColor}
 )
 
-func PrintTable(c *cli.Context, items []interface{}, opts *PrintOptions) {
+func PrintTable(c *cli.Context, w io.Writer, items []interface{}, opts *PrintOptions) {
 	colorFlag := c.String(color.FlagColor)
 	enableColor := colorFlag == string(color.Auto) || colorFlag == string(color.Always)
 	fields := opts.Fields
-	table := tablewriter.NewWriter(opts.Pager)
+	table := tablewriter.NewWriter(w)
 	table.SetBorder(false)
 	table.SetColumnSeparator(opts.Separator)
 

--- a/pkg/output/table_test.go
+++ b/pkg/output/table_test.go
@@ -1,0 +1,84 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package output_test
+
+import (
+	"flag"
+	"os"
+
+	"github.com/temporalio/tctl-kit/pkg/output"
+	"github.com/urfave/cli/v2"
+)
+
+type item struct {
+	Name   string
+	Value  string
+	Nested struct {
+		NName  string
+		NValue string
+	}
+}
+
+func setupTableTest() (*cli.Context, func()) {
+	app := cli.NewApp()
+	flagSet := flag.FlagSet{}
+	ctx := cli.NewContext(app, &flagSet, nil)
+
+	return ctx, func() {}
+}
+
+func ExamplePrintTable() {
+	ctx, teardown := setupTableTest()
+	defer teardown()
+
+	structItems := []*item{
+		{
+			Name:  "foo1",
+			Value: "bar1",
+			Nested: struct {
+				NName  string
+				NValue string
+			}{
+				NName:  "baz1",
+				NValue: "qux1",
+			},
+		},
+	}
+
+	var items []interface{}
+	for _, item := range structItems {
+		items = append(items, item)
+	}
+
+	po := output.PrintOptions{
+		Fields:   []string{"Name", "Value", "Nested.NName", "Nested.NValue"},
+		NoHeader: true,
+	}
+
+	output.PrintTable(ctx, os.Stdout, items, &po)
+
+	// Output:
+	// foo1  bar1  baz1  qux1
+}

--- a/pkg/pager/flag.go
+++ b/pkg/pager/flag.go
@@ -32,7 +32,7 @@ const (
 type PagerOption string
 
 const (
-	Stdout PagerOption = ""
+	Stdout PagerOption = "stdout"
 	Less   PagerOption = "less"
 	More   PagerOption = "more"
 )

--- a/pkg/pager/pager_test.go
+++ b/pkg/pager/pager_test.go
@@ -1,0 +1,74 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package pager_test
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/temporalio/tctl-kit/pkg/pager"
+	"github.com/urfave/cli/v2"
+)
+
+func setupPagerTest() (*cli.Context, func()) {
+	app := cli.NewApp()
+	flagSet := flag.FlagSet{}
+	ctx := cli.NewContext(app, &flagSet, nil)
+
+	return ctx, func() {}
+}
+
+func TestPrintTable_Stdout(t *testing.T) {
+	ctx, teardown := setupPagerTest()
+	defer teardown()
+
+	w, _ := pager.NewPager(ctx, "")
+	assert.Equal(t, w, os.Stdout)
+
+	w, _ = pager.NewPager(ctx, "stdout")
+	assert.Equal(t, w, os.Stdout)
+}
+
+func TestPrintTable_StdoutFallback(t *testing.T) {
+	ctx, teardown := setupPagerTest()
+	defer teardown()
+
+	w, close := pager.NewPager(ctx, "executable-that-doesnt-exist")
+	defer close()
+
+	assert.Equal(t, w, os.Stdout)
+}
+
+func TestPrintTable_Less(t *testing.T) {
+	ctx, teardown := setupPagerTest()
+	defer teardown()
+
+	w, close := pager.NewPager(ctx, "less")
+	defer close()
+
+	assert.NotEqual(t, w, os.Stdout)
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

- Makes stdout always the default output (vs less for Table as it used to be)

## Why?
<!-- Tell your future self why have you made these changes -->

Making the API predictable & explicitly requiring API consumers to choose "less"/other pagers if they want to  

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
