### PR TITLE
Fix panic when it fails to create the config file (#29)

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,6 +23,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -48,9 +49,11 @@ func NewConfig(appName, configName string) (*Config, error) {
 
 	dpath = filepath.Join(dpath, ".config", appName)
 
-	mkfile(dpath, configName+".yaml")
+	cfgPath, err := mkfile(dpath, configName+".yaml")
+	if err != nil {
+		return nil, err
+	}
 
-	cfgPath := filepath.Join(dpath, configName+".yaml")
 	cfg, err := readConfig(cfgPath)
 	if err != nil {
 		return nil, err
@@ -164,7 +167,12 @@ func mkfile(dirPath, filename string) (string, error) {
 
 	fpath := filepath.Join(dirPath, filename)
 
-	if _, err := os.Stat(fpath); err != nil {
+	_, err := os.Stat(fpath)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", err
+		}
+
 		fmt.Printf("creating config file: %v\n", fpath)
 		file, err := os.Create(fpath)
 		if err == nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -38,6 +38,16 @@ const (
 	cfgFile = "test-tctl-kit-config"
 )
 
+func TestNewConfigPermissionDenied(t *testing.T) {
+	expectedError := errors.New("open /tmp.yaml: permission denied")
+
+	_, err := config.NewConfig(appName, "../../../../../../../../../../../../tmp")
+
+	if assert.Error(t, err) {
+		assert.Equal(t, expectedError.Error(), err.Error())
+	}
+}
+
 func TestNewConfigCreatesFile(t *testing.T) {
 	path := getConfigPath(t)
 


### PR DESCRIPTION
## What was changed
if os.Stat returns a permission denied, we exit here and it's properly return in `NewConfig`.

## Why?
It created a panic in tctl.

## Checklist

1. Closes #29 
2. How was this tested:
I added a unit test to cover the Permission Denied case.

3. Any docs updates needed?
No
