### PR TITLE
Return error on missing env

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -115,12 +115,12 @@ func (c *Config) RemoveEnv(name string) error {
 	return c.writeFile()
 }
 
-func (c *Config) EnvProperty(env, key string) string {
+func (c *Config) EnvProperty(env, key string) (string, error) {
 	if env, ok := c.Envs[env]; ok {
-		return env[key]
+		return env[key], nil
 	}
 
-	return ""
+	return "", fmt.Errorf("env not found: %v", env)
 }
 
 func (c *Config) SetEnvProperty(env, key, value string) error {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -339,7 +339,8 @@ func TestEnvProperty(t *testing.T) {
 
 			for envName, envProps := range tc.expect {
 				for key, vExpected := range envProps {
-					vActual := cfg.EnvProperty(envName, key)
+					vActual, err := cfg.EnvProperty(envName, key)
+					assert.NoError(t, err)
 					assert.Equal(t, vActual, vExpected)
 				}
 			}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Started returning error when trying to read env that was not set up

## Why?
<!-- Tell your future self why have you made these changes -->

distinguishing between empty value and env not existing

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

tested with https://github.com/temporalio/temporal-cli/pull/1

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
