### PR TITLE
Rename pre-created env to default

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,6 +31,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const DefaultEnv = "default"
+
 type Config struct {
 	Aliases    map[string]string            `yaml:"aliases"`
 	CurrentEnv string                       `yaml:"current-env"`
@@ -57,7 +59,7 @@ func NewConfig(appName, configName string) (*Config, error) {
 	}
 
 	if cfg.CurrentEnv == "" {
-		cfg.CurrentEnv = "local"
+		cfg.CurrentEnv = DefaultEnv
 	}
 
 	if cfg.Aliases == nil {
@@ -65,7 +67,7 @@ func NewConfig(appName, configName string) (*Config, error) {
 	}
 
 	if cfg.Envs == nil {
-		cfg.Envs = map[string]map[string]string{"local": {}}
+		cfg.Envs = map[string]map[string]string{DefaultEnv: {}}
 	}
 
 	cfg.path = cfgPath

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -374,7 +374,7 @@ func TestSetEnvProperty(t *testing.T) {
 		},
 		"accepts empty value": {
 			input:    []envprop{{"local", "key", ""}},
-			expected: "env:\n    local:\n        key: \"\"\n",
+			expected: "local:\n        key: \"\"",
 			err:      false,
 		},
 		"merges env properties": {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Renamed the default env to "default" instead of "local"

## Why?
<!-- Tell your future self why have you made these changes -->

in Temporal Cli when --env is not provided "default" is going to be taken by default. "local" didn't align well for such case

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

unit tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
