### PR TITLE
Make iterator printer generic

### DIFF
--- a/pkg/iterator/iterator.go
+++ b/pkg/iterator/iterator.go
@@ -24,12 +24,10 @@
 
 package iterator
 
-type (
-	// Iterator represents the interface for iterator
-	Iterator interface {
-		// HasNext return whether this iterator has next value
-		HasNext() bool
-		// Next returns the next item and error
-		Next() (interface{}, error)
-	}
-)
+// Iterator represents the interface for iterator
+type Iterator[C any] interface {
+	// HasNext return whether this iterator has next value
+	HasNext() bool
+	// Next returns the next item and error
+	Next() (C, error)
+}

--- a/pkg/output/printer.go
+++ b/pkg/output/printer.go
@@ -97,7 +97,7 @@ func PrintItems(c *cli.Context, items []interface{}, opts *PrintOptions) error {
 }
 
 // PrintIterator prints items from an iterator based on user flags or print options.
-func PrintIterator(c *cli.Context, iter iterator.Iterator, opts *PrintOptions) error {
+func PrintIterator(c *cli.Context, iter iterator.Iterator[interface{}], opts *PrintOptions) error {
 	limit := c.Int(FlagLimit)
 
 	if opts == nil {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

made `output.PrintIterator` API take generic iterator, not just over interface{} items

## Why?
<!-- Tell your future self why have you made these changes -->

Allows reusing the iterator API when initializing new iterator implementations, e.g consuming the iterator provided by Go SDK `GetWorkflowHistory` API 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Tested with https://github.com/temporalio/cli/pull/110

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
