### PR TITLE
Inherit urfave writer instead of stdout

### DIFF
--- a/pkg/pager/pager.go
+++ b/pkg/pager/pager.go
@@ -46,7 +46,7 @@ const (
 func NewPager(c *cli.Context, pager string) (io.Writer, func()) {
 	noPager := c.Bool(FlagNoPager)
 	if noPager || pager == "" || pager == string(Stdout) || !isatty.IsTerminal(os.Stdout.Fd()) {
-		return os.Stdout, func() {}
+		return c.App.Writer, func() {}
 	}
 
 	exe, err := lookupPager(pager)

--- a/pkg/pager/pager_test.go
+++ b/pkg/pager/pager_test.go
@@ -51,6 +51,10 @@ func TestPrintTable_Stdout(t *testing.T) {
 
 	w, _ = pager.NewPager(ctx, "stdout")
 	assert.Equal(t, w, os.Stdout)
+
+	ctx.App.Writer = os.Stderr
+	w, _ = pager.NewPager(ctx, "")
+	assert.Equal(t, w, os.Stderr)
 }
 
 func TestPrintTable_StdoutFallback(t *testing.T) {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Used `writer` from `urfave/cli` instead of stdout

## Why?
<!-- Tell your future self why have you made these changes -->

Setting a custom writer can be useful in tests

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

updated `TestPrintTable_Stdout`

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
