### PR TITLE
fix address panic when $HOME environment is not defined

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -221,8 +221,10 @@ func validateKey(key string) error {
 
 func configPath(appName, configName string) (string, string, error) {
 	dir, err := os.UserHomeDir()
+
+	// If the HOME env var is not set (can happen if we’re called by a process other than a shell), we still try to construct a writable path
 	if err != nil {
-		return "", "", err
+		dir = os.TempDir()
 	}
 
 	dir = filepath.Join(dir, ".config", appName)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -46,7 +46,12 @@ func TestNewConfigPermissionDenied(t *testing.T) {
 
 	appName := uuid.New()
 	readOnly := os.FileMode(0400)
-	dir = filepath.Join(dir, ".config", appName)
+	defaultPermission := os.FileMode(0755)
+
+	dir = filepath.Join(dir, ".config")
+	os.MkdirAll(dir, defaultPermission)
+
+	dir = filepath.Join(dir, appName)
 	os.MkdirAll(dir, readOnly)
 
 	// umask may have changed config folder permissions, ensure they are correct

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -76,6 +76,17 @@ func TestNewConfigPermissionDenied(t *testing.T) {
 	}
 }
 
+func TestNewConfigWithoutHomeEnv(t *testing.T) {
+	home := os.Getenv("HOME")
+	os.Unsetenv("HOME")
+	defer os.Setenv("HOME", home)
+
+	appName := uuid.New()
+
+	_, err := config.NewConfig(appName, "test")
+	assert.NoError(t, err)
+}
+
 func TestCreatesConfigFileLazily(t *testing.T) {
 	cfg, teardown := setupConfig(t, "")
 	defer teardown()


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please make sure there is an open issue for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
pkg/config/config.go -> 
os.UserHomeDir() returns an error only when $HOME environment is not set. Therefore, instead of returning an error, the dir variable is set to a temporary directory (using the os.TempDir() function), this helps to avoid address panic in the future.

pkg/config/config_test.go -> 
1. Added a test to check when environment $HOME is not set.
2. Сhanged the test because it didn't pass if the .config directory wasn't created before the test was run.


## Why?
I was getting address panic after trying to create a new TCTL config. This was happening because environment $HOME was not set.

## Checklist

1. How was this tested:
- By internal tests, but with unset $HOME environment
- By running temporalio/tctl with modified temporalio/tctl-kit

2. Any docs updates needed? NO